### PR TITLE
Link to GNU gettext & Go versions of 'envsubst'

### DIFF
--- a/podcast/the-changelog-451.md
+++ b/podcast/the-changelog-451.md
@@ -3,5 +3,6 @@
 - [bat](https://github.com/sharkdp/bat)
 - [fzf](https://github.com/junegunn/fzf)
 - [mcfly](https://github.com/cantino/mcfly)
+- [envsubst](https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html) (comes with GNU gettext); [envsubst](https://github.com/a8m/envsubst) (Go implementation)
 - [https://uses.tech](https://uses.tech)
 - [NanoVMs let you run your apps faster and safer with Unikernels](https://runninginproduction.com/podcast/79-nanovms-let-you-run-your-apps-faster-and-safer-with-unikernels)


### PR DESCRIPTION
I _think_ [this](https://github.com/a8m/envsubst) is the Go version of `envsubst` that Nick was referring to at the end of [Changelog #451](https://changelog.fm/451#t=1:06:00).

FYI, on macOS, I had to `sudo port install gettext` to get the GNU gettext `envsubst`.